### PR TITLE
Release/1.1.0

### DIFF
--- a/_out.tf
+++ b/_out.tf
@@ -116,6 +116,11 @@ output "region" {
   value       = data.aws_region.current
 }
 
+output "route53_resolver_rule_associations" {
+  description = "The value provided for var.route53_resolver_rule_associations"
+  value       = var.route53_resolver_rule_associations
+}
+
 output "route_tables" {
   description = "Route tables created for subnet groups in this VPC"
   value = merge({

--- a/_var.tf
+++ b/_var.tf
@@ -107,6 +107,12 @@ variable "nat_gateway_subnets" {
   }
 }
 
+variable "route53_resolver_rule_associations" {
+  description = "Route 53 Resolver rules to associate with this VPC"
+  type        = list(string)
+  default     = []
+}
+
 variable "subnet_groups" {
   description = "Configurations for groups of subnets. TODO better description"
   type = list(object({

--- a/route53-resolver.tf
+++ b/route53-resolver.tf
@@ -1,0 +1,7 @@
+resource "aws_route53_resolver_rule_association" "rule" {
+  for_each = toset(var.route53_resolver_rule_associations)
+
+  name             = var.name
+  resolver_rule_id = each.key
+  vpc_id           = aws_vpc.vpc.id
+}


### PR DESCRIPTION
Release/1.1.0

Add `var.route53_resolver_rule_associations` to make attaching DNS resolver rules a little easier