### PR TITLE
Release/1.2.0

### DIFF
--- a/examples/bastion-hosts/main.tf
+++ b/examples/bastion-hosts/main.tf
@@ -1,5 +1,5 @@
 module "vpc_main" {
-  source = "../"
+  source = "../../"
 
   name       = "main"
   cidr_block = "10.0.0.0/16"

--- a/examples/minimal/main.tf
+++ b/examples/minimal/main.tf
@@ -1,5 +1,5 @@
 module "vpc_main" {
-  source = "../"
+  source = "../../"
 
   name       = "main"
   cidr_block = "10.0.0.0/16"

--- a/examples/three-tier/main.tf
+++ b/examples/three-tier/main.tf
@@ -1,5 +1,5 @@
 module "vpc_main" {
-  source = "../"
+  source = "../../"
 
   name       = "main"
   cidr_block = "10.0.0.0/16"

--- a/examples/transit-gateway/main.tf
+++ b/examples/transit-gateway/main.tf
@@ -1,5 +1,5 @@
 module "vpc_main" {
-  source = "../"
+  source = "../../"
 
   name       = "main"
   cidr_block = "10.0.0.0/16"

--- a/examples/two-tier/main.tf
+++ b/examples/two-tier/main.tf
@@ -1,5 +1,5 @@
 module "vpc_main" {
-  source = "../"
+  source = "../../"
 
   name       = "main"
   cidr_block = "10.0.0.0/16"

--- a/examples/vpc-endpoints/main.tf
+++ b/examples/vpc-endpoints/main.tf
@@ -1,5 +1,5 @@
 module "vpc_main" {
-  source = "../"
+  source = "../../"
 
   name       = "main"
   cidr_block = "10.0.0.0/16"

--- a/examples/vpc-peering/main.tf
+++ b/examples/vpc-peering/main.tf
@@ -1,5 +1,5 @@
 module "vpc_main" {
-  source = "../"
+  source = "../../"
 
   name       = "main"
   cidr_block = "10.0.0.0/16"

--- a/nacl.tf
+++ b/nacl.tf
@@ -4,86 +4,57 @@ resource "aws_network_acl" "nacl" {
   subnet_ids = [for az in var.availability_zones : aws_subnet.subnet["${each.value.name}-${az}"].id]
   vpc_id     = aws_vpc.vpc.id
 
-  dynamic "ingress" {
-    for_each = try(length(each.value.nacl.ingress) > 0, false) ? {
-      for ingress in [
-        for ing in each.value.nacl.ingress : ing if ing.subnet_group == null
-      ] : ingress.rule_no => ingress
-    } : {}
-
-    content {
-      from_port       = ingress.value.from_port
-      to_port         = ingress.value.to_port
-      protocol        = ingress.value.protocol
-      action          = ingress.value.action
-      cidr_block      = ingress.value.cidr_block
-      ipv6_cidr_block = ingress.value.ipv6_cidr_block
-      rule_no         = ingress.value.rule_no
-    }
-  }
-
-  dynamic "ingress" {
-    for_each = try(length(each.value.nacl.ingress) > 0, false) ? {
-      for ingress in flatten([
-        for ing in each.value.nacl.ingress : [
-          for az in var.availability_zones : merge(ing, { az = az })
-        ] if ing.subnet_group != null
-      ]) : ingress.rule_no + index(sort(var.availability_zones), ingress.az) => ingress
-    } : {}
-
-    content {
-      from_port       = ingress.value.from_port
-      to_port         = ingress.value.to_port
-      protocol        = ingress.value.protocol
-      action          = ingress.value.action
-      cidr_block      = aws_subnet.subnet["${ingress.value.subnet_group}-${ingress.value.az}"].cidr_block
-      ipv6_cidr_block = ingress.value.ipv6_cidr_block
-      rule_no         = ingress.value.rule_no + index(sort(var.availability_zones), ingress.value.az)
-    }
-  }
-
-  dynamic "egress" {
-    for_each = try(length(each.value.nacl.egress) > 0, false) ? {
-      for egress in [
-        for eg in each.value.nacl.egress : eg if eg.subnet_group == null
-      ] : egress.rule_no => egress
-    } : {}
-
-    content {
-      from_port       = egress.value.from_port
-      to_port         = egress.value.to_port
-      protocol        = egress.value.protocol
-      action          = egress.value.action
-      cidr_block      = egress.value.cidr_block
-      ipv6_cidr_block = egress.value.ipv6_cidr_block
-      rule_no         = egress.value.rule_no
-    }
-  }
-
-  dynamic "egress" {
-    for_each = try(length(each.value.nacl.egress) > 0, false) ? {
-      for egress in flatten([
-        for eg in each.value.nacl.egress : [
-          for az in var.availability_zones : merge(eg, { az = az })
-        ] if eg.subnet_group != null
-      ]) : egress.rule_no + index(sort(var.availability_zones), egress.az) => egress
-    } : {}
-
-    content {
-      from_port       = egress.value.from_port
-      to_port         = egress.value.to_port
-      protocol        = egress.value.protocol
-      action          = egress.value.action
-      cidr_block      = aws_subnet.subnet["${egress.value.subnet_group}-${egress.value.az}"].cidr_block
-      ipv6_cidr_block = egress.value.ipv6_cidr_block
-      rule_no         = egress.value.rule_no + index(sort(var.availability_zones), egress.value.az)
-    }
-  }
-
   tags = merge(each.value.tags, {
     "Availability Zones"   = join(",", var.availability_zones)
     "Managed By Terraform" = "true"
     "Name"                 = "${var.name}-${each.value.name}"
     "Type"                 = each.value.type
   })
+}
+
+resource "aws_network_acl_rule" "rule" {
+  for_each = {
+    for rule in flatten([
+      for group in var.subnet_groups : concat(
+        [
+          for ingress in coalesce(group.nacl.ingress, []) : ingress.subnet_group != null ? [
+            for az in var.availability_zones : merge(ingress, {
+              az         = az
+              egress     = false
+              group_name = group.name
+              rule_no    = ingress.rule_no + index(sort(var.availability_zones), az)
+            })
+            ] : [merge(ingress, {
+              egress     = false
+              group_name = group.name
+          })]
+        ],
+        [
+          for egress in coalesce(group.nacl.egress, []) : egress.subnet_group != null ? [
+            for az in var.availability_zones : merge(egress, {
+              az         = az
+              egress     = true
+              group_name = group.name
+              rule_no    = egress.rule_no + index(sort(var.availability_zones), az)
+            })
+            ] : [merge(egress, {
+              egress     = true
+              group_name = group.name
+          })]
+        ]
+      ) if group.nacl != null
+    ]) : "${rule.group_name}-${rule.rule_no}" => rule
+  }
+
+  cidr_block = each.value.subnet_group != null ? (
+    aws_subnet.subnet["${each.value.subnet_group}-${each.value.az}"].cidr_block
+  ) : each.value.cidr_block
+  egress          = each.value.egress
+  from_port       = each.value.from_port
+  ipv6_cidr_block = each.value.ipv6_cidr_block
+  network_acl_id  = aws_network_acl.nacl[each.value.group_name].id
+  protocol        = each.value.protocol
+  rule_action     = each.value.action
+  rule_number     = each.value.rule_no
+  to_port         = each.value.to_port
 }

--- a/route-table.tf
+++ b/route-table.tf
@@ -15,44 +15,6 @@ resource "aws_route_table" "route_table" {
     ]) : table.id => table
   }
 
-  dynamic "route" {
-    for_each = try(length(each.value.routes) > 0, false) ? {
-      for route in each.value.routes : coalesce(route.cidr_block, route.ipv6_cidr_block, route.prefix_list_id) => route
-    } : {}
-
-    content {
-      cidr_block                 = route.value.cidr_block
-      ipv6_cidr_block            = route.value.ipv6_cidr_block
-      destination_prefix_list_id = route.value.prefix_list_id
-      carrier_gateway_id         = route.value.carrier_gateway_id
-      gateway_id                 = route.value.gateway_id
-      instance_id                = route.value.instance_id
-      nat_gateway_id             = route.value.nat_gateway_id
-      network_interface_id       = route.value.network_interface_id
-      transit_gateway_id         = route.value.transit_gateway_id
-      vpc_endpoint_id            = route.value.vpc_endpoint_id
-      vpc_peering_connection_id  = route.value.vpc_peering_connection_id
-    }
-  }
-
-  dynamic "route" {
-    for_each = each.value.type == "private" ? toset([1]) : toset([])
-
-    content {
-      cidr_block     = "0.0.0.0/0"
-      nat_gateway_id = aws_nat_gateway.ngw[each.value.az].id
-    }
-  }
-
-  dynamic "route" {
-    for_each = each.value.type == "public" ? toset([1]) : toset([])
-
-    content {
-      cidr_block = "0.0.0.0/0"
-      gateway_id = aws_internet_gateway.igw.id
-    }
-  }
-
   vpc_id = aws_vpc.vpc.id
 
   tags = merge(each.value.tags, {
@@ -61,6 +23,76 @@ resource "aws_route_table" "route_table" {
     "Name"                 = "${var.name}-${each.value.id}"
     "Type"                 = each.value.type
   })
+}
+
+resource "aws_route" "igw_route" {
+  for_each = toset(flatten([
+    for group in var.subnet_groups : group.name if group.type == "public"
+  ]))
+
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.igw.id
+  route_table_id         = aws_route_table.route_table[each.key].id
+}
+
+resource "aws_route" "ngw_route" {
+  for_each = {
+    for route in flatten([
+      for group in var.subnet_groups : [
+        for az in var.availability_zones : {
+          az             = az
+          route_table_id = "${group.name}-${az}"
+        }
+      ] if group.type == "private"
+    ]) : route.route_table_id => route
+  }
+
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id         = aws_nat_gateway.ngw[each.value.az].id
+  route_table_id         = aws_route_table.route_table[each.key].id
+}
+
+resource "aws_route" "route" {
+  for_each = {
+    for route in flatten([
+      for group in var.subnet_groups : group.type == "private" ? flatten([
+        for az in var.availability_zones : [
+          for route in coalesce(group.routes, []) : merge(route, {
+            destination = coalesce(
+              route.cidr_block,
+              route.ipv6_cidr_block,
+              route.prefix_list_id
+            )
+            route_table_id = "${group.name}-${az}"
+          })
+        ]
+        ]) : [
+        for route in coalesce(group.routes, []) : merge(route, {
+          destination = coalesce(
+            route.cidr_block,
+            route.ipv6_cidr_block,
+            route.prefix_list_id
+          )
+          route_table_id = group.name
+        })
+      ]
+    ]) : "${route.route_table_id}-${route.destination}" => route
+  }
+
+  carrier_gateway_id          = each.value.carrier_gateway_id
+  destination_cidr_block      = each.value.cidr_block
+  destination_ipv6_cidr_block = each.value.ipv6_cidr_block
+  destination_prefix_list_id  = each.value.prefix_list_id
+  egress_only_gateway_id      = each.value.egress_only_gateway_id
+  gateway_id                  = each.value.gateway_id
+  instance_id                 = each.value.instance_id
+  nat_gateway_id              = each.value.nat_gateway_id
+  local_gateway_id            = each.value.local_gateway_id
+  network_interface_id        = each.value.network_interface_id
+  route_table_id              = aws_route_table.route_table[each.value.route_table_id].id
+  transit_gateway_id          = each.value.transit_gateway_id
+  vpc_endpoint_id             = each.value.vpc_endpoint_id
+  vpc_peering_connection_id   = each.value.vpc_peering_connection_id
 }
 
 resource "aws_route_table_association" "association" {

--- a/vpc-endpoint.tf
+++ b/vpc-endpoint.tf
@@ -76,6 +76,15 @@ resource "aws_network_acl" "endpoint_nacl" {
     rule_no    = 1
   }
 
+  ingress {
+    from_port  = 1024
+    to_port    = 65535
+    protocol   = "tcp"
+    action     = "allow"
+    cidr_block = "0.0.0.0/0"
+    rule_no    = 2
+  }
+
   egress {
     from_port  = 0
     to_port    = 65535


### PR DESCRIPTION
Release/1.2.0

Per suggestion from a buddy of mine, inline routes and nacl rules tend to produce difficult-to-interpret diffs when routes or nacl rules are added/ removed. Thus, this release removes inline routes and rules and replaces them with independent resources for the same objects. The exceptions to this are routes and nacl rules that will not change (nat gateways get routes to an internet gateway, and need no others, for example).

This release also adds an ingress rule for the endpoint subnets, so that they can receive responses they receive for requests made to external IPs.