### PR TITLE
Release/1.2.1

### DIFF
--- a/nacl.tf
+++ b/nacl.tf
@@ -43,7 +43,7 @@ resource "aws_network_acl_rule" "rule" {
           })]
         ]
       ) if group.nacl != null
-    ]) : "${rule.group_name}-${rule.rule_no}" => rule
+    ]) : "${rule.group_name}-${rule.egress ? "egress" : "ingress"}-${rule.rule_no}" => rule
   }
 
   cidr_block = each.value.subnet_group != null ? (

--- a/transit-gateway.tf
+++ b/transit-gateway.tf
@@ -53,7 +53,7 @@ resource "aws_route_table" "tgw_route_table" {
 
 resource "aws_route" "tgw_route" {
   for_each = {
-    for route in flatten([
+    for route in distinct(flatten([
       for group in var.subnet_groups : [
         for route in coalesce(group.routes, []) : merge(route, {
           destination = coalesce(
@@ -63,7 +63,7 @@ resource "aws_route" "tgw_route" {
           )
         }) if route.transit_gateway_id != null
       ]
-    ]) : route.destination => route
+    ])) : route.destination => route
   }
 
   destination_cidr_block      = each.value.cidr_block

--- a/vpc-endpoint.tf
+++ b/vpc-endpoint.tf
@@ -28,7 +28,7 @@ resource "aws_subnet" "endpoint_subnet" {
       cidr_block = cidrsubnet(
         var.cidr_block,
         coalesce(var.vpc_endpoint_subnets.newbits, 27 - parseint(split("/", var.cidr_block)[1], 10)),
-        coalesce(var.vpc_endpoint_subnets.first_netnum, ceil(length(var.availability_zones))) + index(sort(var.availability_zones), az)
+        coalesce(var.vpc_endpoint_subnets.first_netnum, length(var.availability_zones)) + index(sort(var.availability_zones), az)
       )
     }
   }


### PR DESCRIPTION
Release/1.2.1

- Make sure NACL rules are unique (duplicate rule numbers between ingress/ egress)
- Make sure TGW route keys are unique (in case multiple subnet groups make the same routes)
- Remove useless `ceil()` statement (left over from trying to do fancy subnet math in development)